### PR TITLE
Fix #18: Do not use bare `except`, specify exception instead

### DIFF
--- a/Commands.py
+++ b/Commands.py
@@ -322,7 +322,7 @@ def ASSIGNMENT(line_used):
                 to_be_eval += " " + str(V)
         try:
             to_be_eval = eval(to_be_eval)
-        except:
+        except ValueError:
             pass
 
         if array:


### PR DESCRIPTION
## Description
This PR removes the bare exception and adds a ```ValueError``` for the bare ```except``` statement in ```Commands.py```.
Fixes issue #18 

I went with the ```ValueError``` because that seemed to be the general exception for all the assignments done in the ```try``` statement.